### PR TITLE
Updates for logging and tracing (deleteme)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,13 +86,6 @@ linters-settings:
               - github.com/mailgun/errors
             reason: "Deprecated"
 
-  stylecheck:
-    # Select the Go version to target.
-    # Default: 1.13
-#    go: "1.19"
-    # https://staticcheck.io/docs/options#checks
-    checks: ["all"]
-
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
@@ -107,6 +100,3 @@ run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
   timeout: 5m
-
-#  skip-dirs:
-#    - googleapis

--- a/global.go
+++ b/global.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/mailgun/holster/v4/syncutil"
+	"github.com/mailgun/holster/v4/tracing"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
@@ -36,7 +37,9 @@ type globalManager struct {
 	instance                    *V1Instance // TODO circular import? V1Instance also holds a reference to globalManager
 	metricGlobalSendDuration    prometheus.Summary
 	metricGlobalSendQueueLength prometheus.Gauge
+	metricGlobalSendErrors      prometheus.Counter
 	metricBroadcastDuration     prometheus.Summary
+	metricBroadcastErrors       prometheus.Counter
 	metricGlobalQueueLength     prometheus.Gauge
 }
 
@@ -56,10 +59,18 @@ func newGlobalManager(conf BehaviorConfig, instance *V1Instance) *globalManager 
 			Name: "gubernator_global_send_queue_length",
 			Help: "The count of requests queued up for global broadcast.  This is only used for GetRateLimit requests using global behavior.",
 		}),
+		metricGlobalSendErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gubernator_global_send_errors",
+			Help: "The count of errors during global send to owning peer",
+		}),
 		metricBroadcastDuration: prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:       "gubernator_broadcast_duration",
 			Help:       "The duration of GLOBAL broadcasts to peers in seconds.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001},
+		}),
+		metricBroadcastErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gubernator_broadcast_errors",
+			Help: "The count of errors during UpdatePeerGlobals",
 		}),
 		metricGlobalQueueLength: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "gubernator_global_queue_length",
@@ -170,7 +181,7 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 	fan := syncutil.NewFanOut(gm.conf.GlobalPeerRequestsConcurrency)
 	// Send the rate limit requests to their respective owning peers.
 	for _, p := range peerRequests {
-		fan.Run(func(in interface{}) error {
+		fan.Run(func(in any) error {
 			p := in.(*pair)
 			ctx, cancel := context.WithTimeout(context.Background(), gm.conf.GlobalTimeout)
 			_, err := p.client.GetPeerRateLimits(ctx, &p.req)
@@ -179,6 +190,7 @@ func (gm *globalManager) sendHits(hits map[string]*RateLimitReq) {
 			if err != nil {
 				gm.log.WithError(err).
 					Errorf("while sending global hits to '%s'", p.client.Info().GRPCAddress)
+				gm.metricGlobalSendErrors.Inc()
 			}
 			return nil
 		}, p)
@@ -232,6 +244,8 @@ func (gm *globalManager) runBroadcasts() {
 
 // broadcastPeers broadcasts global rate limit statuses to all other peers
 func (gm *globalManager) broadcastPeers(ctx context.Context, updates map[string]*RateLimitReq) {
+	ctx = tracing.StartScope(ctx)
+	defer tracing.EndScope(ctx, nil)
 	defer prometheus.NewTimer(gm.metricBroadcastDuration).ObserveDuration()
 	var req UpdatePeerGlobalsReq
 	reqState := RateLimitReqState{IsOwner: false}
@@ -264,16 +278,18 @@ func (gm *globalManager) broadcastPeers(ctx context.Context, updates map[string]
 			continue
 		}
 
-		fan.Run(func(in interface{}) error {
+		fan.Run(func(in any) error {
 			peer := in.(*PeerClient)
 			ctx, cancel := context.WithTimeout(ctx, gm.conf.GlobalTimeout)
 			_, err := peer.UpdatePeerGlobals(ctx, &req)
 			cancel()
 
 			if err != nil {
+				gm.metricBroadcastErrors.Inc()
 				// Only log if it's an unknown error
 				if !errors.Is(err, context.Canceled) && errors.Is(err, context.DeadlineExceeded) {
-					gm.log.WithError(err).Errorf("while broadcasting global updates to '%s'", peer.Info().GRPCAddress)
+					gm.log.WithField("batch_size", len(req.Globals)).WithError(err).
+						Errorf("while broadcasting global updates to '%s'", peer.Info().GRPCAddress)
 				}
 			}
 			return nil

--- a/peer_client.go
+++ b/peer_client.go
@@ -189,7 +189,11 @@ func (c *PeerClient) GetPeerRateLimits(ctx context.Context, r *GetPeerRateLimits
 
 // UpdatePeerGlobals sends global rate limit status updates to a peer
 func (c *PeerClient) UpdatePeerGlobals(ctx context.Context, r *UpdatePeerGlobalsReq) (resp *UpdatePeerGlobalsResp, err error) {
-
+	ctx = tracing.StartScope(ctx, trace.WithAttributes(
+		attribute.String("peer", c.Info().GRPCAddress),
+		attribute.Int("item_count", len(r.Globals)),
+	))
+	defer func() { tracing.EndScope(ctx, err) }()
 	// See NOTE above about RLock and wg.Add(1)
 	c.wgMutex.Lock()
 	c.wg.Add(1)

--- a/workers.go
+++ b/workers.go
@@ -201,7 +201,6 @@ func (p *WorkerPool) dispatch(worker *Worker) {
 				logrus.Error("workerPool worker stopped because channel closed")
 				return
 			}
-
 			resp := new(response)
 			resp.rl, resp.err = worker.handleGetRateLimit(req.ctx, req.request, req.reqState, worker.cache)
 			select {
@@ -262,7 +261,7 @@ func (p *WorkerPool) dispatch(worker *Worker) {
 }
 
 // GetRateLimit sends a GetRateLimit request to worker pool.
-func (p *WorkerPool) GetRateLimit(ctx context.Context, rlRequest *RateLimitReq, reqState RateLimitReqState) (*RateLimitResp, error) {
+func (p *WorkerPool) GetRateLimit(ctx context.Context, rlRequest *RateLimitReq, reqState RateLimitReqState) (_ *RateLimitResp, err error) {
 	// Delegate request to assigned channel based on request key.
 	worker := p.getWorker(rlRequest.HashKey())
 	queueGauge := metricWorkerQueue.WithLabelValues("GetRateLimit", worker.name)


### PR DESCRIPTION
- Add tracing detail in some key places.
- Remove unnecessary traces.
- Add metrics:
  - `gubernator_global_send_errors`: Counter of errors during global send
  - `gubernator_broadcast_errors: Counter of errors during global broadcast
  - `gubernator_updatepeerglobals_item_count`: Summary gauge of items sent to UpdatePeerGlobals requests from global broadcast.  Useful for seeing how much global updating is happening.